### PR TITLE
Add support for running tests without an EnhancedTestSet wrapper.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 	find . -name "*.jl.*.cov" -exec rm -f {} \;
 	@echo
 	@echo Running tests
-	julia --color=yes -e 'import Pkg; Pkg.test("TestTools"; coverage=true)'
+	julia --color=yes -e 'import Pkg; Pkg.test(; coverage=true)'
 	@echo
 	@echo Generating code coverage report
 	@jlcoverage

--- a/README-Testing.md
+++ b/README-Testing.md
@@ -1,0 +1,33 @@
+Testing TestTools.jl
+====================
+
+Unit tests may be run using any of the following methods:
+
+* from the shell using the Make target
+
+  ```shell
+  $ make test
+  ```
+
+* from the Julia REPL
+
+  * without collection of coverage data
+
+    ```julia
+    import Pkg; Pkg.test("TestTools")
+    ```
+
+  * with collection of coverage data
+
+    ```julia
+    import Pkg; Pkg.test("TestTools"; coverage=true)
+    ```
+
+* from the shell using `jltest`
+
+  ```shell
+  $ jltest -W test/runtests.jl
+  ```
+
+  When using `jltest` to run the unit tests, note that the `-W` or `--no-wrapper` option
+  is required for the tests that check the output failing tests to work correctly.

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Style errors found. Files modified to correct errors.
 
   * [TestSetExtensions](https://github.com/ssfrr/TestSetExtensions.jl)
 
-    * The `EnhancedTestSet` type and methods are based extensively on
-      `TestsetExtensions.ExtendedTestSet`.
+    * The base code for `EnhancedTestSet` (which implements diffs for comparisons and
+      progress dots) comes directly from `TestsetExtensions.ExtendedTestSet`.
 
     * The `run_tests()` and `autodetect_tests()` methods are essentially a re-implementation
       and refactoring of the `TestsetExtensions.@includetests` macro as methods.

--- a/docs/src/acknowledgements.md
+++ b/docs/src/acknowledgements.md
@@ -12,8 +12,8 @@
 
   * [TestSetExtensions](https://github.com/ssfrr/TestSetExtensions.jl)
 
-    * The `EnhancedTestSet` type and methods are based extensively on
-      `TestsetExtensions.ExtendedTestSet`.
+    * The base code for `EnhancedTestSet` (which implements diffs for comparisons and
+      progress dots) comes directly from `TestsetExtensions.ExtendedTestSet`.
 
     * The `run_tests()` and `autodetect_tests()` methods are essentially a re-implementation
       and refactoring of the `TestsetExtensions.@includetests` macro as methods.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,7 +11,7 @@ TestTools.install
 TestTools.uninstall
 ```
 
-## `jltest` Module
+## `jltest`
 
 ```@docs
 jltest
@@ -19,14 +19,14 @@ jltest.find_tests
 jltest.run_tests
 ```
 
-## `jlcoverage` Module
+## `jlcoverage`
 
 ```@docs
 jlcoverage
 jlcoverage.display_coverage
 ```
 
-## `EnhancedTestSet` Type
+## `EnhancedTestSet`
 
 ```@docs
 jltest.EnhancedTestSet

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -142,9 +142,11 @@ jltest.run_test(@__DIR__)
 TestTools runs tests within an [`EnhancedTestSet`](@ref TestTools.jltest.EnhancedTestSet),
 which augments the `DefaultTestSet` with the following functionality:
 
-* display diffs for failed comparison tests (when possible) and
+* display diffs for failed comparison tests (when possible),
 
-* support fail-fast (i.e., stop testing at first failure).
+* support fail-fast (i.e., stop testing at first failure), and
+
+* display progress dots.
 
 !!! tip
     No special effort is required to benefit from these enhancements. Simply use the

--- a/examples/jlcodestyle/README.md
+++ b/examples/jlcodestyle/README.md
@@ -17,7 +17,7 @@
 By default, `jlcodestyle` applies the Blue style, so running the following command will
 detect style errors:
 
-```julia
+```shell
 $ jlcodestyle default-style.jl
 ```
 

--- a/src/jltest/cli/main.jl
+++ b/src/jltest/cli/main.jl
@@ -35,4 +35,9 @@ if args["version"]
 end
 
 # Run main program
-jltest.cli.run(args["tests"]; fail_fast=args["fail-fast"], verbose=args["verbose"])
+jltest.cli.run(
+    args["tests"];
+    fail_fast=args["fail-fast"],
+    no_wrapper=args["no-wrapper"],
+    verbose=args["verbose"],
+)

--- a/test/jltest/cli_tests.jl
+++ b/test/jltest/cli_tests.jl
@@ -41,6 +41,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => false,
+        "no-wrapper" => false,
         "verbose" => false,
         "version" => false,
         "tests" => Vector{String}(),
@@ -54,6 +55,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => true,
+        "no-wrapper" => false,
         "verbose" => false,
         "version" => false,
         "tests" => Vector{String}(),
@@ -65,6 +67,33 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => true,
+        "no-wrapper" => false,
+        "verbose" => false,
+        "version" => false,
+        "tests" => Vector{String}(),
+    )
+    @test args == expected_args
+
+    # --- no-wrapper
+
+    # Case: raw_args = "--no-wrapper"
+    raw_args = ["--no-wrapper"]
+    args = cli.parse_args(; raw_args=raw_args)
+    expected_args = Dict(
+        "fail-fast" => false,
+        "no-wrapper" => true,
+        "verbose" => false,
+        "version" => false,
+        "tests" => Vector{String}(),
+    )
+    @test args == expected_args
+
+    # Case: raw_args = "-W"
+    raw_args = ["-W"]
+    args = cli.parse_args(; raw_args=raw_args)
+    expected_args = Dict(
+        "fail-fast" => false,
+        "no-wrapper" => true,
         "verbose" => false,
         "version" => false,
         "tests" => Vector{String}(),
@@ -78,6 +107,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => false,
+        "no-wrapper" => false,
         "verbose" => true,
         "version" => false,
         "tests" => Vector{String}(),
@@ -89,6 +119,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => false,
+        "no-wrapper" => false,
         "verbose" => true,
         "version" => false,
         "tests" => Vector{String}(),
@@ -102,6 +133,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => false,
+        "no-wrapper" => false,
         "verbose" => false,
         "version" => true,
         "tests" => Vector{String}(),
@@ -113,6 +145,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => false,
+        "no-wrapper" => false,
         "verbose" => false,
         "version" => true,
         "tests" => Vector{String}(),
@@ -125,6 +158,7 @@ using TestTools.jltest: cli, EnhancedTestSet
     args = cli.parse_args(; raw_args=raw_args)
     expected_args = Dict(
         "fail-fast" => false,
+        "no-wrapper" => false,
         "verbose" => false,
         "version" => false,
         "tests" => ["test-1", "test-2.jl"],

--- a/test/jltest/utils_tests.jl
+++ b/test/jltest/utils_tests.jl
@@ -73,7 +73,7 @@ using TestTools.jltest
            Evaluated: 2 == 1
 
         Stacktrace:
-         [1]
+          [1]
         """
     )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,18 +238,18 @@ print("jltest/cli_tests: ")
 
     @test error_type == TestSetException
     @test error_message ==
-        "Some tests did not pass: 45 passed, 4 failed, 0 errored, 0 broken."
+        "Some tests did not pass: 47 passed, 4 failed, 0 errored, 0 broken."
 
     # Check output from EnhancedTestSet
     expected_output = strip(
         """
-        $(joinpath("jltest", "cli_tests")): .............................
+        $(joinpath("jltest", "cli_tests")): ...............................
 
 
         Test Summary:                     | Pass  Fail  Total
-        jltest                            |   45     4     49
-          cli tests                       |   45     4     49
-            jltest.cli.parse_args()       |    8            8
+        jltest                            |   47     4     51
+          cli tests                       |   47     4     51
+            jltest.cli.parse_args()       |   10           10
             jltest.cli.run(): basic tests |   36     4     40
               All tests                   |    4            4
               All tests                   |    3     1      4


### PR DESCRIPTION
* This functionality makes it possible to use `jltest` to run the tests in `test/runtests.jl`:

  ```shell
  $ jltest -W test/runtests.jl
  ```

* Update documentation.